### PR TITLE
Add config option for tlsa key algorithm

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -85,6 +85,10 @@ horizontal dash).
   ``key "mykey" { algorithm hmac-sha256; secret "c2VjcmV0Cg=="; };``
   the matching JSON content is ``{"mykey": "c2VjcmV0Cg=="}``.
 
+- keyalgorithm = *hmac-sha256*
+
+  If keyfile is set define which key algorithm the TSIG key uses
+
 - nameserver = *hostname | ip-address*
 
   Host name or IP address for your nameserver. Name resolution is

--- a/letsdns/liveupdate.py
+++ b/letsdns/liveupdate.py
@@ -38,12 +38,13 @@ class DnsLiveUpdate(Action):
         """Update DNS record using the dnspython library. Return 0 to indicate success."""
         zone = conf.get_mandatory('domain')
         path = conf.get('keyfile')
+        keyalgorithm = conf.get('keyalgorithm', 'hmac-sha256')
         if path:
             with open(path, 'r') as f:
                 keyring = tsigkeyring.from_text(json.load(f))
         else:  # pragma: no cover
             keyring = None
-        update = Update(zone=zone, keyring=keyring)
+        update = Update(zone=zone, keyring=keyring, keyalgorithm=keyalgorithm)
         for port in conf.get_tcp_ports():
             name = record_name(conf, port)
             update.delete(name)


### PR DESCRIPTION
This PR allows to set the TSIG key algorithm.

Tested with latest bind9 version and `hmac-sha512` key

**Currently `LetsDNS` enforces `hmac-sha256`**

bind9
```
key "dane-key" {
    algorithm hmac-sha512;
    secret "N4cr5g+Tb4fStB+DTLWWAP3DJuQsfttRAR81M0Y78fQBVtwR1vBzQnpSsxezdqlaSqV5TLdAkRhT8tqD6tP6Ig==";
};

zone "example.com" {
    type master;
    file "/var/lib/bind/example.com";
    update-policy {
        grant dane-key. name _25._tcp.smtp.example.com. TLSA;
    };
};
```

letsdns
```
apt install python3-pip
pip install letsdns

mkdir -p /etc/letsdns
touch /etc/letsdns/dane-rfc2136.ini
chmod 400 /etc/letsdns/dane-rfc2136.ini
cat << 'EOF' > /etc/letsdns/dane-rfc2136.ini
[example.com]
action = dane-tlsa
nameserver = 98.218.57.129
cert_0_path = /etc/letsencrypt/live/smtp.example.com/cert.pem
tcp_ports = 25
domain = example.com
hostname = smtp
keyfile = /etc/letsdns/credentials.json
keyalgorithm = hmac-sha512
ttl = 300
EOF

touch /etc/letsdns/credentials.json
chmod 400 /etc/letsdns/credentials.json
cat << 'EOF' > /etc/letsdns/credentials.json
{"dane-key.": "N4cr5g+Tb4fStB+DTLWWAP3DJuQsfttRAR81M0Y78fQBVtwR1vBzQnpSsxezdqlaSqV5TLdAkRhT8tqD6tP6Ig=="}
EOF

export LOG_LEVEL=DEBUG
letsdns /etc/letsdns/dane-rfc2136.ini
```

successful bind9 log:
```
20-Jul-2023 17:16:15.999 client @0xxx xxx.xxx.xxx.xxx#24860/key dane-key: updating zone 'example.com/IN': delete all rrsets from name '_25._tcp.smtp.example.com'
20-Jul-2023 17:16:15.999 client @0xxx xxx.xxx.xxx.xxx#24860/key dane-key: updating zone 'example.com/IN': deleting rrset at '_25._tcp.smtp.example.com' TLSA
20-Jul-2023 17:16:15.999 client @0xxx xxx.xxx.xxx.xxx#24860/key dane-key: updating zone 'example.com/IN': adding an RR at '_25._tcp.smtp.example.com' TLSA 3 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXX
...
```